### PR TITLE
플랫폼 차트 컴포넌트 구현

### DIFF
--- a/src/pages/dashboard/PlatformChart.tsx
+++ b/src/pages/dashboard/PlatformChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Chart from 'react-apexcharts';
 import { IPlatformItems } from '../../types/platform';
 import { createPlatformSeries } from '../../utils/helpers/charts';
-import { platformBarOptions } from '../../utils/constants/charts';
+import { PLATFORM_CHART_OPTIONS } from '../../utils/constants/charts';
 interface PlatformChartProps {
   platforms: IPlatformItems;
 }
@@ -10,7 +10,7 @@ interface PlatformChartProps {
 function PlatformChart({ platforms }: PlatformChartProps): JSX.Element {
   const series = createPlatformSeries(platforms);
 
-  return <Chart options={platformBarOptions} series={series} type='bar' />;
+  return <Chart options={PLATFORM_CHART_OPTIONS} series={series} type='bar' />;
 }
 
 export default PlatformChart;

--- a/src/pages/dashboard/PlatformChart.tsx
+++ b/src/pages/dashboard/PlatformChart.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Chart from 'react-apexcharts';
+import { IPlatformItems } from '../../types/platform';
+import { createPlatformSeries } from '../../utils/helpers/charts';
+import { platformBarOptions } from '../../utils/constants/charts';
+interface PlatformChartProps {
+  platforms: IPlatformItems;
+}
+
+function PlatformChart({ platforms }: PlatformChartProps): JSX.Element {
+  const series = createPlatformSeries(platforms);
+
+  return <Chart options={platformBarOptions} series={series} type='bar' />;
+}
+
+export default PlatformChart;

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -22,6 +22,14 @@ const platformBarOptions: ApexOptions = {
   xaxis: {
     categories: ['광고비', '매출', '노출수', '클릭수', '전환수'],
   },
+  yaxis: {
+    labels: {
+      formatter: (value: number) => {
+        const formatted = `${Number(value.toFixed(0))}%`;
+        return formatted;
+      },
+    },
+  },
   fill: {
     opacity: 1,
   },

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -25,11 +25,29 @@ const PLATFORM_CHART_OPTIONS: ApexOptions = {
     },
   },
   tooltip: {
-    y: {
-      formatter: (value: number) => {
-        const formatted = `${value.toFixed(0)}`;
-        return formatted;
-      },
+    custom: function ({ series, seriesIndex, dataPointIndex }) {
+      const indicators = ['cost', 'sales', 'impression', 'click', 'conversion'];
+      const target = indicators[dataPointIndex];
+
+      const moneyFormat = () => {
+        const money = Number(series[seriesIndex][dataPointIndex].toFixed(0)).toLocaleString();
+        return '<div class="arrow_box">' + '<span>' + money + '원' + '</span>' + '</div>';
+      };
+
+      const countFormat = () => {
+        const count = Number(series[seriesIndex][dataPointIndex].toFixed(0)).toLocaleString();
+        return '<div class="arrow_box">' + '<span>' + count + '건' + '</span>' + '</div>';
+      };
+
+      const formatMapper: { [index: string]: () => string } = {
+        cost: moneyFormat,
+        sales: moneyFormat,
+        impression: countFormat,
+        click: countFormat,
+        conversion: countFormat,
+      };
+
+      return formatMapper[target]();
     },
   },
   legend: {

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -7,6 +7,11 @@ const platformBarOptions: ApexOptions = {
     stacked: true,
     stackType: '100%',
   },
+  plotOptions: {
+    bar: {
+      borderRadius: 10,
+    },
+  },
   responsive: [
     {
       breakpoint: 480,
@@ -25,11 +30,18 @@ const platformBarOptions: ApexOptions = {
   yaxis: {
     labels: {
       formatter: (value: number) => {
-        const formatted = `${Number(value.toFixed(0))}%`;
+        const formatted = `${value.toFixed(0)}%`;
         return formatted;
       },
     },
-    tooltip: {},
+  },
+  tooltip: {
+    y: {
+      formatter: (value: number) => {
+        const formatted = `${value.toFixed(0)}`;
+        return formatted;
+      },
+    },
   },
   fill: {
     opacity: 1,

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -29,12 +29,14 @@ const platformBarOptions: ApexOptions = {
         return formatted;
       },
     },
+    tooltip: {},
   },
   fill: {
     opacity: 1,
   },
   legend: {
     position: 'bottom',
+    horizontalAlign: 'right',
     offsetX: 0,
     offsetY: 0,
   },

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -1,0 +1,35 @@
+import { ApexOptions } from 'apexcharts';
+
+const platformBarOptions: ApexOptions = {
+  chart: {
+    type: 'bar',
+    height: 350,
+    stacked: true,
+    stackType: '100%',
+  },
+  responsive: [
+    {
+      breakpoint: 480,
+      options: {
+        legend: {
+          position: 'bottom',
+          offsetX: -10,
+          offsetY: 0,
+        },
+      },
+    },
+  ],
+  xaxis: {
+    categories: ['광고비', '매출', '노출수', '클릭수', '전환수'],
+  },
+  fill: {
+    opacity: 1,
+  },
+  legend: {
+    position: 'bottom',
+    offsetX: 0,
+    offsetY: 0,
+  },
+};
+
+export { platformBarOptions };

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -12,18 +12,7 @@ const platformBarOptions: ApexOptions = {
       borderRadius: 10,
     },
   },
-  responsive: [
-    {
-      breakpoint: 480,
-      options: {
-        legend: {
-          position: 'bottom',
-          offsetX: -10,
-          offsetY: 0,
-        },
-      },
-    },
-  ],
+  colors: ['#E60023', '#0C9D58', '#4185F3', '#F4B500'],
   xaxis: {
     categories: ['광고비', '매출', '노출수', '클릭수', '전환수'],
   },
@@ -43,15 +32,22 @@ const platformBarOptions: ApexOptions = {
       },
     },
   },
-  fill: {
-    opacity: 1,
-  },
   legend: {
     position: 'bottom',
     horizontalAlign: 'right',
-    offsetX: 0,
-    offsetY: 0,
   },
+  responsive: [
+    {
+      breakpoint: 480,
+      options: {
+        legend: {
+          position: 'bottom',
+          offsetX: -10,
+          offsetY: 0,
+        },
+      },
+    },
+  ],
 };
 
 export { platformBarOptions };

--- a/src/utils/constants/charts.tsx
+++ b/src/utils/constants/charts.tsx
@@ -1,6 +1,6 @@
 import { ApexOptions } from 'apexcharts';
 
-const platformBarOptions: ApexOptions = {
+const PLATFORM_CHART_OPTIONS: ApexOptions = {
   chart: {
     type: 'bar',
     height: 350,
@@ -50,4 +50,4 @@ const platformBarOptions: ApexOptions = {
   ],
 };
 
-export { platformBarOptions };
+export { PLATFORM_CHART_OPTIONS };

--- a/src/utils/helpers/charts.tsx
+++ b/src/utils/helpers/charts.tsx
@@ -79,9 +79,6 @@ const createPlatformSeries = (platforms: IPlatformItems) => {
 
     return series;
   }
-  function isTheLastElement(index: number, array: number[]) {
-    return index === array.length - 1;
-  }
 };
 
 export { createPlatformSeries };

--- a/src/utils/helpers/charts.tsx
+++ b/src/utils/helpers/charts.tsx
@@ -6,11 +6,12 @@ const createPlatformSeries = (platforms: IPlatformItems) => {
   return series;
 
   function initPlatformMap() {
+    // 광고비, 매출, 노출수, 클릭수, 전환수, 전체건수 항목으로 초기화
     const platformMap = new Map<string, number[]>([
-      ['google', Array(5).fill(0)],
-      ['naver', Array(5).fill(0)],
-      ['facebook', Array(5).fill(0)],
-      ['kakao', Array(5).fill(0)],
+      ['google', Array(6).fill(0)],
+      ['naver', Array(6).fill(0)],
+      ['facebook', Array(6).fill(0)],
+      ['kakao', Array(6).fill(0)],
     ]);
 
     return platformMap;
@@ -20,13 +21,14 @@ const createPlatformSeries = (platforms: IPlatformItems) => {
       const indicators = platformMap.get(platform.channel);
 
       if (indicators) {
-        const [cost, sales, impression, click, conversion] = indicators;
+        const [cost, sales, impression, click, conversion, count] = indicators;
 
         const newCost = platform.cost + cost;
         const newSales = platform.roas * platform.cost + sales;
         const newImpression = platform.imp + impression;
         const newClick = platform.click + click;
         const newConversion = platform.cvr * platform.imp + conversion;
+        const newCount = count + 1;
 
         platformMap.set(platform.channel, [
           newCost,
@@ -34,14 +36,22 @@ const createPlatformSeries = (platforms: IPlatformItems) => {
           newImpression,
           newClick,
           newConversion,
+          newCount,
         ]);
       }
     });
 
     platformMap.forEach(
       (indicators: number[], platformName: string, self: Map<string, number[]>) => {
-        const average = indicators.map((indicator) => indicator / platforms.length);
-        self.set(platformName, average);
+        const averaged = indicators.map((indicator, index, self) => {
+          const count = self[self.length - 1];
+
+          const averagedIndicator = indicator / count;
+          return averagedIndicator;
+        });
+
+        const countRemoved = averaged.slice(0, 5);
+        self.set(platformName, countRemoved);
       },
     );
 
@@ -68,6 +78,9 @@ const createPlatformSeries = (platforms: IPlatformItems) => {
     ];
 
     return series;
+  }
+  function isTheLastElement(index: number, array: number[]) {
+    return index === array.length - 1;
   }
 };
 

--- a/src/utils/helpers/charts.tsx
+++ b/src/utils/helpers/charts.tsx
@@ -1,0 +1,74 @@
+import { IPlatformItems, IPlatformItem } from '../../types/platform';
+
+const createPlatformSeries = (platforms: IPlatformItems) => {
+  const map = processIndicatorsToMap(platforms, initPlatformMap());
+  const series = convertMapToSeries(map);
+  return series;
+
+  function initPlatformMap() {
+    const platformMap = new Map<string, number[]>([
+      ['google', Array(5).fill(0)],
+      ['naver', Array(5).fill(0)],
+      ['facebook', Array(5).fill(0)],
+      ['kakao', Array(5).fill(0)],
+    ]);
+
+    return platformMap;
+  }
+  function processIndicatorsToMap(platforms: IPlatformItems, platformMap: Map<string, number[]>) {
+    platforms.forEach((platform: IPlatformItem) => {
+      const indicators = platformMap.get(platform.channel);
+
+      if (indicators) {
+        const [cost, sales, impression, click, conversion] = indicators;
+
+        const newCost = platform.cost + cost;
+        const newSales = platform.roas * platform.cost + sales;
+        const newImpression = platform.imp + impression;
+        const newClick = platform.click + click;
+        const newConversion = platform.cvr * platform.imp + conversion;
+
+        platformMap.set(platform.channel, [
+          newCost,
+          newSales,
+          newImpression,
+          newClick,
+          newConversion,
+        ]);
+      }
+    });
+
+    platformMap.forEach(
+      (indicators: number[], platformName: string, self: Map<string, number[]>) => {
+        const average = indicators.map((indicator) => indicator / platforms.length);
+        self.set(platformName, average);
+      },
+    );
+
+    return platformMap;
+  }
+  function convertMapToSeries(platformMap: Map<string, number[]>) {
+    const series = [
+      {
+        name: '구글',
+        data: platformMap.get('google') || [],
+      },
+      {
+        name: '네이버',
+        data: platformMap.get('naver') || [],
+      },
+      {
+        name: '페이스북',
+        data: platformMap.get('facebook') || [],
+      },
+      {
+        name: '카카오',
+        data: platformMap.get('kakao') || [],
+      },
+    ];
+
+    return series;
+  }
+};
+
+export { createPlatformSeries };


### PR DESCRIPTION
# 개요

#1 플랫폼 광고 현황을 보여주는 누적 막대형 차트를 구현

- props에서 플랫폼별 실적 데이터를 제공 받는다
- 플랫폼별 실적 데이터를 차트에서 사용하는 series 데이터로 가공한다
- 차트 옵션은 상수로 분리하여 관리한다