### PR TITLE
campaign 데이터 react query로 crud 구현

### DIFF
--- a/src/queries/httpRequest.ts
+++ b/src/queries/httpRequest.ts
@@ -1,5 +1,17 @@
 import { AxiosInstance } from 'axios';
 
-export function get(service: AxiosInstance, queryString: string) {
+export function get(service: AxiosInstance, queryString = '') {
   return service.get(queryString).then((response) => response.data);
+}
+
+export function post(service: AxiosInstance, data: unknown) {
+  return service.post('', data);
+}
+
+export function put(service: AxiosInstance, queryString = '', data: unknown) {
+  return service.put(queryString, data);
+}
+
+export function _delete(service: AxiosInstance, queryString = '') {
+  return service.delete(queryString);
 }

--- a/src/queries/queryRequest.ts
+++ b/src/queries/queryRequest.ts
@@ -1,6 +1,12 @@
-import { useQuery } from 'react-query';
-import { OVERALL, PLATFORM, overallService, platformService } from './services';
-import { get } from './httpRequest';
+import { useQuery, useMutation } from 'react-query';
+import { get, post, put, _delete } from './httpRequest';
+import { typeStatus, ICampaignItemBase } from '../types/campaign';
+import { overallService, platformService, campaignService } from './services';
+
+import { OVERALL_CONSTANTS, PLATFORM_CONSTANTS, CAMPAIGN_CONSTANTS } from '../utils/constants/data';
+const { OVERALL } = OVERALL_CONSTANTS;
+const { PLATFORM } = PLATFORM_CONSTANTS;
+const { CAMPAIGN, STATUS_ALL } = CAMPAIGN_CONSTANTS;
 
 export function getDashboard(startDate: string, endDate: string) {
   const query = `?date_gte=${startDate}&date_lte=${endDate}`;
@@ -9,4 +15,26 @@ export function getDashboard(startDate: string, endDate: string) {
   const platform = useQuery([PLATFORM, startDate], () => get(platformService, query));
 
   return [overall, platform];
+}
+
+export function getCampaignByStatus(status: typeStatus) {
+  const query = status === STATUS_ALL ? '' : `?status=${status}`;
+
+  return useQuery([CAMPAIGN, status], () => get(campaignService, query), { staleTime: 0 });
+}
+
+export function createCampaign(campaign: ICampaignItemBase) {
+  return useMutation(() => post(campaignService, campaign));
+}
+
+export function updateCampaign(id: number, campaign: ICampaignItemBase) {
+  const query = `/${id}`;
+
+  return useMutation(() => put(campaignService, query, campaign));
+}
+
+export function deleteCampaign(id: number) {
+  const query = `/${id}`;
+
+  return useMutation(() => _delete(campaignService, query));
 }

--- a/src/queries/services.ts
+++ b/src/queries/services.ts
@@ -1,19 +1,16 @@
 import axios from 'axios';
+import { OVERALL_CONSTANTS, PLATFORM_CONSTANTS, CAMPAIGN_CONSTANTS } from '../utils/constants/data';
 
 const BASE_URL = 'http://localhost:8000';
 
-export const OVERALL = 'overall';
-export const PLATFORM = 'platform';
-export const CAMPAGIN = 'campaign';
-
 export const overallService = axios.create({
-  baseURL: `${BASE_URL}/${OVERALL}/`,
+  baseURL: `${BASE_URL}/${OVERALL_CONSTANTS.OVERALL}/`,
 });
 
 export const platformService = axios.create({
-  baseURL: `${BASE_URL}/${PLATFORM}/`,
+  baseURL: `${BASE_URL}/${PLATFORM_CONSTANTS.PLATFORM}/`,
 });
 
 export const campaignService = axios.create({
-  baseURL: `${BASE_URL}/${CAMPAGIN}/`,
+  baseURL: `${BASE_URL}/${CAMPAIGN_CONSTANTS.CAMPAIGN}/`,
 });

--- a/src/types/campaign.d.ts
+++ b/src/types/campaign.d.ts
@@ -1,9 +1,12 @@
-export interface ICampaignItem {
-  id: number;
+import { CAMPAIGN_CONSTANTS } from '../utils/constants/data';
+const { STATUS_ALL, STATUS_ACTIVE, STATUS_ENDED } = CAMPAIGN_CONSTANTS;
+type typeStatus = typeof STATUS_ALL | typeof STATUS_ACTIVE | typeof STATUS_ENDED;
+
+export interface ICampaignItemBase {
   adType: string;
   title: string;
   budget: number;
-  status: string;
+  status: typeStatus;
   startDate: string;
   endDate: string | null;
   report: {
@@ -13,9 +16,13 @@ export interface ICampaignItem {
   };
 }
 
-export type ICampaginItems = ICampaginItem[];
+export interface ICampaignItem extends ICampaignItemBase {
+  id: number;
+}
+
+export type ICampaignItems = ICampaignItem[];
 
 export interface ICampaign {
   count: number;
-  items: ICampaginItems;
+  items: ICampaignItems;
 }

--- a/src/utils/constants/data.ts
+++ b/src/utils/constants/data.ts
@@ -1,0 +1,18 @@
+export const OVERALL_CONSTANTS = {
+  OVERALL: 'overall',
+} as const;
+
+export const PLATFORM_CONSTANTS = {
+  PLATFORM: 'platform',
+  GOOGLE: 'google',
+  KAKAO: 'kakao',
+  NAVER: 'naver',
+  FACEBOOK: 'facebook',
+} as const;
+
+export const CAMPAIGN_CONSTANTS = {
+  CAMPAIGN: 'campaign',
+  STATUS_ALL: 'all',
+  STATUS_ACTIVE: 'active',
+  STATUS_ENDED: 'ended',
+} as const;


### PR DESCRIPTION
# 개요
- campaign 데이터 react query로 crud 구현

# 요구사항
- [x] campaign 데이터를 위한 get, post, put, delete http 메소드 구현
- [x] react query를 사용하여 get, post, put, delete http 메소드를 호출할 수 있도록 구현
- [x] 전역에서 사용하는 상수를 관리할 수 있는 ts 파일 생성 (utils/constants/data.ts)
- [x] campaign type의 status를 기존 string에서 'all' | 'active' | 'ended'로 변경 (상수 사용)
