### PR TITLE
광고관리 페이지에서 campaign 데이터 받아오도록 구현

### DIFF
--- a/src/pages/adManagement/Wrapper.tsx
+++ b/src/pages/adManagement/Wrapper.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { getCampaignByStatus } from '../../queries/queryRequest';
+import { typeStatus, ICampaignItem } from '../../types/campaign';
+import Card from './Card';
+
+interface IWrapper {
+  status: typeStatus;
+}
+
+export default function Wrapper({ status }: IWrapper) {
+  const { data: campaign } = getCampaignByStatus(status);
+
+  return (
+    <>
+      {campaign.map((campaignItem: ICampaignItem) => (
+        <Card
+          key={campaignItem.id}
+          campaignItem={campaignItem}
+          onDelete={() => {
+            console.log('delete');
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/pages/adManagement/index.tsx
+++ b/src/pages/adManagement/index.tsx
@@ -1,7 +1,56 @@
-import React from 'react';
+import React, { Suspense, useState } from 'react';
+import { CAMPAIGN_CONSTANTS } from '../../utils/constants/data';
+import { typeStatus } from '../../types/campaign';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { FormControl } from '@mui/material';
+import MenuItem from '@mui/material/MenuItem';
+import Wrapper from './Wrapper';
+
+const ALL = '전체';
+const ACTIVE = '진행중';
+const ENDED = '종료';
+const selectItems = [ALL, ACTIVE, ENDED];
+type typeStatusKo = typeof ALL | typeof ACTIVE | typeof ENDED;
 
 function AdManagement() {
-  return <div>AdManagement</div>;
+  const [statusKo, setStatusKo] = useState<typeStatusKo>(ALL);
+
+  const handleSelectChange = (event: SelectChangeEvent) => {
+    const {
+      target: { value },
+    } = event;
+
+    setStatusKo(value as typeStatusKo);
+  };
+
+  return (
+    <>
+      <FormControl variant='standard' sx={{ m: 1, minWidth: 120 }}>
+        <Select value={statusKo} onChange={handleSelectChange}>
+          {selectItems.map((item: string) => (
+            <MenuItem key={item} value={item}>
+              {item}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <Suspense fallback={<div>Loading</div>}>
+        <Wrapper status={getStatusEn(statusKo)} />
+      </Suspense>
+    </>
+  );
 }
 
 export default AdManagement;
+
+function getStatusEn(statusKo: typeStatusKo): typeStatus {
+  const { STATUS_ALL, STATUS_ACTIVE, STATUS_ENDED } = CAMPAIGN_CONSTANTS;
+  const statusObj = {
+    [ALL]: STATUS_ALL,
+    [ACTIVE]: STATUS_ACTIVE,
+    [ENDED]: STATUS_ENDED,
+  };
+
+  return statusObj[statusKo];
+}


### PR DESCRIPTION
# 개요
- campaign 데이터를 광고관리 페이지에서 사용할 수 있어야 한다.

# 구현
- [x] index.ts에서 select로 [전체, 진행중, 종료]를 Wrapper.tsx로 내려준다.
- [x] Wrapper는 받은 status를 기준으로 campaign 데이터를 불러온다.
- [x] Wrapper의 비동기 호출 loading 관리는 index.ts의 suspens가 처리한다.

close #22 