### PR TITLE
updateCampaign을 함수 내에서 사용할 수 없는 문제 해결

### DIFF
--- a/src/queries/queryRequest.ts
+++ b/src/queries/queryRequest.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { get, post, put, _delete } from './httpRequest';
 import { typeStatus, ICampaignItemBase } from '../types/campaign';
 import { overallService, platformService, campaignService } from './services';
@@ -20,21 +20,31 @@ export function getDashboard(startDate: string, endDate: string) {
 export function getCampaignByStatus(status: typeStatus) {
   const query = status === STATUS_ALL ? '' : `?status=${status}`;
 
-  return useQuery([CAMPAIGN, status], () => get(campaignService, query), { staleTime: 0 });
+  return useQuery([CAMPAIGN, status], () => get(campaignService, query));
 }
 
-export function createCampaign(campaign: ICampaignItemBase) {
-  return useMutation(() => post(campaignService, campaign));
+export function createCampaign() {
+  return useMutation((campaign: ICampaignItemBase) => post(campaignService, campaign));
 }
 
-export function updateCampaign(id: number, campaign: ICampaignItemBase) {
+export function updateCampaign(id: number) {
   const query = `/${id}`;
 
-  return useMutation(() => put(campaignService, query, campaign));
+  return useMutation((campaign: ICampaignItemBase) => put(campaignService, query, campaign));
 }
 
 export function deleteCampaign(id: number) {
   const query = `/${id}`;
 
   return useMutation(() => _delete(campaignService, query));
+}
+
+type typeDataName = typeof OVERALL | typeof PLATFORM | typeof CAMPAIGN;
+export function invalidateQueriesByName(name: typeDataName) {
+  const queryClient = useQueryClient();
+  return queryClient.invalidateQueries({
+    predicate: (query) => {
+      return query.queryKey[0] === name;
+    },
+  });
 }


### PR DESCRIPTION
# 개요
- useMutation을 실행하는 updateCampaign를 함수 내에서 사용하면 invalid-hook-call 에러가 발생한다.

# 요구사항
- updateCampaign는 사용하는 컴포넌트에서 마운트 시 최초 1회만 호출하고
- updateCampaign으로 반환되는 mutate 객체를 활용해 create, update, delete 한다!!

# 추가 수정
- campaign 데이터도 캐싱이 가능하게 수정
- invalidate query 함수를 추가

# 사용 방법
const { mutateAsync } = updateCampaign(campaign.id);

const handleSubmit = async (campaign: ICampaignItem) => {
  await mutateAsync(campaign);
  await invalidateQueriesByName(CAMPAIGN_CONSTANTS.CAMPAIGN);
  navigate('/ad');
};