### PR TITLE
invalidateQueriesByName 함수 호출 시 발생하는 문제 해결

### DIFF
--- a/src/queries/queryRequest.ts
+++ b/src/queries/queryRequest.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, QueryClient } from 'react-query';
 import { get, post, put, _delete } from './httpRequest';
 import { typeStatus, ICampaignItemBase } from '../types/campaign';
 import { overallService, platformService, campaignService } from './services';
@@ -40,8 +40,7 @@ export function deleteCampaign(id: number) {
 }
 
 type typeDataName = typeof OVERALL | typeof PLATFORM | typeof CAMPAIGN;
-export function invalidateQueriesByName(name: typeDataName) {
-  const queryClient = useQueryClient();
+export function invalidateQueriesByName(queryClient: QueryClient, name: typeDataName) {
   return queryClient.invalidateQueries({
     predicate: (query) => {
       return query.queryKey[0] === name;


### PR DESCRIPTION
# 개요
- invalidateQueriesByName 함수 호출에 필요한 queryClient를 react query에서 제공하는 hook으로 호출하는데 이걸 컴포넌트 외부에서 호출해서 에러가 발생하였다.

# 수정
- queryClient는 invalidateQueriesByName 함수를 사용하는 곳에서 const queryClient = useQueryClient(); 로 받아와 매개변수로 넘겨주면 된다.

# 구현
```javascript
import { useQueryClient } from 'react-query';
const queryClient = useQueryClient();
const onSubmit = async (values: ICampaignItemBase) => {
  await mutateAsync(values); // CampaignItem
  await invalidateQueriesByName(queryClient, CAMPAIGN_CONSTANTS.CAMPAIGN);
  navigate('/ad');
};

```