### PR TITLE
광고 수정, 등록, 삭제에 사용하는 useMutation refactoring

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,8 +1,6 @@
 import React, { MouseEvent, useState } from 'react';
 import { ICampaignItem } from '../../types/campaign';
-import { deleteCampaign, invalidateQueriesByName } from '../../queries/queryRequest';
-import { useQueryClient } from 'react-query';
-import { CAMPAIGN_CONSTANTS } from '../../utils/constants/data';
+import { useDeleteCampaign } from '../../queries/queryRequest';
 import styled from 'styled-components';
 import { Button, Card as DefaultCard, CardActions, CardContent, CardHeader } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -15,8 +13,7 @@ interface CardProps {
 
 function Card({ campaignItem }: CardProps) {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const queryClient = useQueryClient();
-  const { mutateAsync } = deleteCampaign(campaignItem.id);
+  const mutateAsync = useDeleteCampaign(campaignItem.id);
 
   const navigate = useNavigate();
 
@@ -30,8 +27,6 @@ function Card({ campaignItem }: CardProps) {
 
   const handleDeleteClick = async () => {
     await mutateAsync();
-    await invalidateQueriesByName(queryClient, CAMPAIGN_CONSTANTS.CAMPAIGN);
-
     setAnchorEl(null);
   };
 

--- a/src/pages/adAdd/index.tsx
+++ b/src/pages/adAdd/index.tsx
@@ -2,16 +2,14 @@ import React, { useState } from 'react';
 import { Alert } from '@mui/material';
 import AdForm from '../../components/adForm/AdForm';
 import { ICampaignItemBase } from '../../types/campaign';
-import { createCampaign, invalidateQueriesByName } from '../../queries/queryRequest';
+import { useCreateCampaign } from '../../queries/queryRequest';
 import { useNavigate } from 'react-router-dom';
 import { CAMPAIGN_CONSTANTS } from '../../utils/constants/data';
-import { useQueryClient } from 'react-query';
 
 function AdAdd() {
   const navigate = useNavigate();
 
-  const { mutateAsync } = createCampaign();
-  const queryClient = useQueryClient();
+  const mutateAsync = useCreateCampaign();
 
   const [validValue, setValidValue] = useState(true);
   const [errorMessage, setErrorMessage] = useState(
@@ -54,7 +52,6 @@ function AdAdd() {
     if (validateValues(values)) {
       setValidValue(true);
       await mutateAsync({ ...values });
-      await invalidateQueriesByName(queryClient, CAMPAIGN_CONSTANTS.CAMPAIGN);
       navigate('/ad');
     } else {
       setValidValue(false);

--- a/src/pages/adEdit/index.tsx
+++ b/src/pages/adEdit/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useQueryClient } from 'react-query';
 import { ICampaignItem } from '../../types/campaign';
 import AdForm from '../../components/adForm/AdForm';
-import { updateCampaign, invalidateQueriesByName } from '../../queries/queryRequest';
-import { CAMPAIGN_CONSTANTS } from '../../utils/constants/data';
+import { useUpdateCampaign } from '../../queries/queryRequest';
 import styled from 'styled-components';
 
 function AdEdit() {
@@ -13,8 +11,8 @@ function AdEdit() {
   const campaign = location.state as ICampaignItem;
   const navigate = useNavigate();
   const hasState = location.state;
-  const { mutateAsync } = updateCampaign(campaign.id);
-  const queryClient = useQueryClient();
+
+  const mutateAsync = useUpdateCampaign(campaign.id);
 
   React.useEffect(() => {
     if (!hasState) {
@@ -24,7 +22,6 @@ function AdEdit() {
 
   const handleSubmit = async (campaign: ICampaignItem) => {
     await mutateAsync(campaign);
-    await invalidateQueriesByName(queryClient, CAMPAIGN_CONSTANTS.CAMPAIGN);
     navigate('/ad');
   };
 


### PR DESCRIPTION
# 개요
- 수정, 등록, 삭제 후에는 react query의 캐시를 날려주어야 한다.
- 기존 방식은 가져다 쓰는 곳에서 mutate() 하고 직접 캐시를 삭제해주어야 했음.
- 매우 불편하여 mutate()와 캐시 삭제 함수를 하나의 함수로 만들어 return 해주는 방식으로 개선

# 구현

- 수정 전 코드
```javascript
/* queryRequest.ts */
export function updateCampaign(id: number) {
  const query = `/${id}`;

  return useMutation((campaign: ICampaignItemBase) => put(campaignService, query, campaign));
}

/* 가져다 쓰는 곳 */
const { mutateAsync } = updateCampaign(campaign.id);
const queryClient = useQueryClient();

const handleSubmit = async (campaign: ICampaignItem) => {
  await mutateAsync(campaign);
  await invalidateQueriesByName(queryClient, CAMPAIGN_CONSTANTS.CAMPAIGN);
  navigate('/ad');
};
```

- 수정 후 코드
```javascript
/* queryRequest.ts */
export function useUpdateCampaign(id: number) {
  const query = `/${id}`;
  const { mutateAsync } = useMutation((campaign: ICampaignItemBase) =>
    put(campaignService, query, campaign),
  );

  const queryClient = useQueryClient();

  return async function (campaign: ICampaignItemBase) {
    await mutateAsync(campaign);
    await invalidateQueriesByName(queryClient, CAMPAIGN_CONSTANTS.CAMPAIGN);
  };
}

/* 가져다 쓰는 곳 */
const mutateAsync = useUpdateCampaign(campaign.id);

const handleSubmit = async (campaign: ICampaignItem) => {
  await mutateAsync(campaign);
  navigate('/ad');
};
```